### PR TITLE
Fix phpunit tests environment initialization

### DIFF
--- a/settingslib.php
+++ b/settingslib.php
@@ -54,6 +54,11 @@ class admin_setting_configtext_int_only extends admin_setting_configtext {
     public function validate($data) {
         global $PAGE;
 
+        // Don't force the plugin to be fully set up when initializing PHPUNIT tests environment.
+        if (defined('PHPUNIT_UTIL') && strlen($data) === 0) {
+            return true;
+        }
+
         // Don't force the plugin to be fully set up when installing.
         if ($PAGE->pagelayout === 'maintenance' && strlen($data) === 0) {
             return true;
@@ -71,6 +76,11 @@ class admin_setting_config_tii_secret_key extends admin_setting_configpasswordun
      */
     public function validate($data) {
         global $PAGE;
+
+        // Don't force the plugin to be fully set up when initializing PHPUNIT tests environment.
+        if (defined('PHPUNIT_UTIL') && strlen($data) === 0) {
+            return true;
+        }
 
         // Don't force the plugin to be fully set up when installing.
         if ($PAGE->pagelayout === 'maintenance' && strlen($data) === 0) {


### PR DESCRIPTION
Aims to fix [job run test errors](https://github.com/lbailey-ucsf/moodle/actions/runs/11828453745):

```
) core\adminlib_test::test_admin_apply_default_settings
Unexpected debugging() call detected.
Debugging: Error applying default setting 'turnitintooltwo/accountid': This value is not valid
* line 8956 of /lib/adminlib.php: call to debugging()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8887 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 173 of /lib/tests/adminlib_test.php: call to admin_apply_default_settings()
* line 1617 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to core\adminlib_test->test_admin_apply_default_settings()
* line 1223 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 72 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 729 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 973 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 651 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 146 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 99 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 107 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()
Debugging: Error applying default setting 'turnitintooltwo/secretkey': This value is not valid
* line 8956 of /lib/adminlib.php: call to debugging()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8921 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 8887 of /lib/adminlib.php: call to admin_apply_default_settings()
* line 173 of /lib/tests/adminlib_test.php: call to admin_apply_default_settings()
* line 1617 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to core\adminlib_test->test_admin_apply_default_settings()
* line 1223 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 72 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 729 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 973 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 651 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 146 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 99 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 107 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()
```