### PR TITLE
T-589 UCSFCLE_404 Pepare Turn It In Two Tool for M4.4

### DIFF
--- a/settingslib.php
+++ b/settingslib.php
@@ -54,6 +54,11 @@ class admin_setting_configtext_int_only extends admin_setting_configtext {
     public function validate($data) {
         global $PAGE;
 
+        // Don't force the plugin to be fully set up when initializing PHPUNIT tests environment.
+        if (defined('PHPUNIT_UTIL') && strlen($data) === 0) {
+            return true;
+        }
+
         // Don't force the plugin to be fully set up when installing.
         if ($PAGE->pagelayout === 'maintenance' && strlen($data) === 0) {
             return true;
@@ -71,6 +76,11 @@ class admin_setting_config_tii_secret_key extends admin_setting_configpasswordun
      */
     public function validate($data) {
         global $PAGE;
+
+        // Don't force the plugin to be fully set up when initializing PHPUNIT tests environment.
+        if (defined('PHPUNIT_UTIL') && strlen($data) === 0) {
+            return true;
+        }
 
         // Don't force the plugin to be fully set up when installing.
         if ($PAGE->pagelayout === 'maintenance' && strlen($data) === 0) {


### PR DESCRIPTION
This PR merges a [Fix forphpunit tests environment initialization](https://github.com/ucsf-education/moodle-mod_turnitintooltwo/commit/5ada02b59f6d12e502c679208e9e5195ed6c6446) in the stable branch of this plugin